### PR TITLE
Add prediction endpoint and update client

### DIFF
--- a/client/managers/manager.py
+++ b/client/managers/manager.py
@@ -2,7 +2,6 @@ from sklearn.model_selection import train_test_split
 from client.ui.menu import Menu
 from client.utils.cleaner import Cleaner
 from client.utils.extract import Extract
-from server.core.classifier import Classifier
 from server.tests.test_accuracy import Tester
 import requests
 import pandas as pd
@@ -49,8 +48,17 @@ class Manager:
                 if self.model:
                     # Ask the user to choose values for specific parameters
                     chosen_params = Menu.get_params(self.params_and_values)
-                    print(f"the answer is:  {Classifier.get_the_most_probability_predict(self.model, chosen_params)}")
+                    response = requests.post(
+                        f"{self.URL}predict",
+                        json={"trained_model": self.model, "params": chosen_params},
+                    )
 
+                    if response.status_code != 200:
+                        print(f"Server error: {response.status_code}")
+                        print(f"Text response: {response.text}")
+                    elif response.ok:
+                        prediction = response.json().get("prediction")
+                        print(f"the answer is:  {prediction}")
                 else:
                     print("choose a file to work first")
 

--- a/server/app/endpoints.py
+++ b/server/app/endpoints.py
@@ -7,6 +7,7 @@ from server.core.naive_bayes_trainer import Naive_bayesian_trainer
 from server.utils.convert_numpy_types import convert_numpy_object_to_numbers
 from typing import Dict, List, Any
 from server.tests.test_accuracy import Tester
+from server.core.classifier import Classifier
 
 router = APIRouter()
 
@@ -39,5 +40,14 @@ def check_accuracy(data:Dict[str,Any]) -> dict:
     test_df = pd.DataFrame(data["test_df"])
     accuracy =  Tester.check_accuracy_percentage(trained_model,  test_df)
     return {"accuracy":accuracy}
+
+
+@router.post("/predict")
+def predict(data: Dict[str, Any]) -> dict:
+    """Return a prediction from a trained model."""
+    trained_model = data["trained_model"]
+    params = data["params"]
+    prediction = Classifier.get_the_most_probability_predict(trained_model, params)
+    return {"prediction": prediction}
 
 


### PR DESCRIPTION
## Summary
- add `/predict` endpoint on the server
- call the new endpoint from the client manager when requesting predictions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6878e65eb0f883319260f3dca6550ad9