### PR TITLE
Add quit option for CLI menu

### DIFF
--- a/client/managers/manager.py
+++ b/client/managers/manager.py
@@ -19,7 +19,7 @@ class Manager:
         running=True
 
         while running:
-            user_selection=Menu.show_menu()
+            user_selection = Menu.show_menu()
 
             if user_selection=="1":
                 try:
@@ -44,7 +44,7 @@ class Manager:
                     print(f"Error: {e}")
 
 
-            elif user_selection== "3":
+            elif user_selection == "3":
                 if self.model:
                     # Ask the user to choose values for specific parameters
                     chosen_params = Menu.get_params(self.params_and_values)
@@ -62,6 +62,9 @@ class Manager:
                 else:
                     print("choose a file to work first")
 
+            elif user_selection in ["4", "q", "Q", "quit", "exit"]:
+                print("Exiting...")
+                running = False
             else:
                 print("invalid input,try again")
 

--- a/client/ui/menu.py
+++ b/client/ui/menu.py
@@ -8,10 +8,13 @@ class Menu:
     @staticmethod
     def show_menu():
         print("\nwhat would you like to do")
-        choise= input("1. select a local csv file to work with\n"
-                      "2. copy URL for a csv file\n"
-                      "3. Analyze by bayesian model statistics")
-        return choise
+        choise = input(
+            "1. select a local csv file to work with\n"
+            "2. copy URL for a csv file\n"
+            "3. Analyze by bayesian model statistics\n"
+            "4. Quit\n"
+        )
+        return choise.strip()
 
 
     @staticmethod


### PR DESCRIPTION
## Summary
- extend menu options to include quitting
- update manager run loop to handle quitting

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687951b0d9988331bcb895765656849f